### PR TITLE
remove superfluous composer.json entries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,21 +6,10 @@
     "require": {
         "php": "^7.2",
         "contao/core-bundle": "^4.4",
-        "symfony/framework-bundle": "^3.4"
-    },
-    "conflict": {
-        "contao/core": "*",
-        "contao/manager-plugin": "<2.0 || >=3.0"
     },
     "autoload": {
         "psr-4": {
-            "Doctrine\\Common\\Cache\\": "src/Doctrine/Common/Cache/"
+            "": "src/"
         },
-        "classmap": [
-            "src/"
-        ]
     },
-    "config": {
-        "preferred-install": "dist"
-    }
 }


### PR DESCRIPTION
The most important change here is the removal of `"symfony/framework-bundle": "^3.4"`, since you are not actually using the `symfony/framework-bundle` in this package. Otherwise this fix package will unnecessarily limit the symfony/framework-bundle version.

Also the conflicts seem unnecessary to me.

I have also simplified the autoloading.

The config is only relevant for the root composer.json.